### PR TITLE
Update paths from rust-lang-nursery to rust-dev-tools

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,7 +1,7 @@
 [package]
 name = "semverver"
 description = "Automatic verification of SemVer adhrence in rust library crates"
-repository = "https://github.com/rust-lang-nursery/rust-semverver"
+repository = "https://github.com/rust-dev-tools/rust-semverver"
 
 readme = "README.md"
 keywords = ["semver", "plugin"]
@@ -13,8 +13,8 @@ authors = ["Inokentiy Babushkin <twk@twki.de>"]
 license-file = "LICENSE"
 
 [badges]
-travis-ci = { repository = "rust-lang-nursery/rust-semverver" }
-appveyor = { repository = "rust-lang-nursery/rust-semverver" }
+travis-ci = { repository = "rust-dev-tools/rust-semverver" }
+appveyor = { repository = "rust-dev-tools/rust-semverver" }
 
 [[bin]]
 name = "cargo-semver"

--- a/README.md
+++ b/README.md
@@ -1,6 +1,6 @@
 # rust-semverver
 
-[![Travis Build Status](https://travis-ci.org/rust-lang-nursery/rust-semverver.svg?branch=master)](https://travis-ci.org/rust-lang-nursery/rust-semverver)
+[![Travis Build Status](https://travis-ci.org/rust-dev-tools/rust-semverver.svg?branch=master)](https://travis-ci.org/rust-dev-tools/rust-semverver)
 [![AppVeyor Build status](https://ci.appveyor.com/api/projects/status/qktm3ndv6cnbj01m?svg=true)](https://ci.appveyor.com/project/ibabushkin/rust-semverver)
 [![Current Version](https://meritbadge.herokuapp.com/semverver)](https://crates.io/crates/semverver)
 
@@ -11,7 +11,7 @@ analyzes the current crate's source code for changes compared to the most recent
 on `crates.io`.
 
 Details on the work done during GSoC 2017 can be found
-[here](https://github.com/rust-lang-nursery/rust-semverver/blob/master/doc/gsoc.md).
+[here](https://github.com/rust-dev-tools/rust-semverver/blob/master/doc/gsoc.md).
 
 ## Background
 
@@ -21,7 +21,7 @@ said dummy and all necessary analysis is performed in that context, where type i
 and other resources are available.
 
 More information on the inner workings of the tool can be found
-[here](https://github.com/rust-lang-nursery/rust-semverver/blob/master/doc/impl_notes.md).
+[here](https://github.com/rust-dev-tools/rust-semverver/blob/master/doc/impl_notes.md).
 
 ## Installation
 
@@ -46,7 +46,7 @@ You can also install the newest version of the tool from git:
 
 ```sh
 $ rustup update nightly
-$ cargo +nightly install --git https://github.com/rust-lang-nursery/rust-semverver
+$ cargo +nightly install --git https://github.com/rust-dev-tools/rust-semverver
 ```
 
 <details>
@@ -60,7 +60,7 @@ $ cargo +nightly install --git https://github.com/rust-lang-nursery/rust-semverv
 $ rustup update nightly
 $ rustup default nightly
 
-$ git clone https://github.com/rust-lang-nursery/rust-semverver
+$ git clone https://github.com/rust-dev-tools/rust-semverver
 $ cd rust-semverver
 $ cargo install
 ```


### PR DESCRIPTION
It appears that the repository was moved from the nursery to dev-tools, but the paths were not updated.