### PR TITLE
Update rust-semverver driver 

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -25,7 +25,8 @@ name = "rust-semverver"
 path = "src/bin/rust_semverver.rs"
 
 [dependencies]
-cargo = "0.32"
+cargo = { git = "https://github.com/gnzlbg/cargo", branch = "revert_6193" }
+failure = "0.1"
 crates-io = "0.20"
 env_logger = "0.6"
 log = "0.4"

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -25,7 +25,7 @@ name = "rust-semverver"
 path = "src/bin/rust_semverver.rs"
 
 [dependencies]
-cargo = { git = "https://github.com/gnzlbg/cargo", branch = "revert_6193" }
+cargo-semverver = "0.34"
 failure = "0.1"
 crates-io = "0.20"
 env_logger = "0.6"

--- a/src/bin/cargo_semver.rs
+++ b/src/bin/cargo_semver.rs
@@ -138,16 +138,7 @@ impl<'a> WorkInfo<'a> {
         };
 
         let package_set = PackageSet::new(&package_ids, sources, config)?;
-        let mut downloads = package_set.enable_download()?;
-        let package = if let Some(package) = downloads.start(package_ids[0])? {
-            package
-        } else {
-            downloads.wait()?;
-            downloads
-                .start(package_ids[0])?
-                .expect("started download did not finish after wait")
-        };
-
+        let package = package_set.get_one(package_ids[0])?;
         let workspace = Workspace::ephemeral(package.clone(), config, None, false)?;
 
         Ok(Self {

--- a/src/semcheck/mapping.rs
+++ b/src/semcheck/mapping.rs
@@ -32,7 +32,7 @@ pub type InherentImplSet = BTreeSet<(DefId, DefId)>;
 /// Definitions and simple `DefId` mappings are kept separate to record both kinds of
 /// correspondence losslessly. The *access* to the stored data happens through the same API,
 /// however. A reverse mapping is also included, but only for `DefId` lookup.
-#[cfg_attr(feature = "cargo-clippy", allow(clippy::stutter))]
+#[cfg_attr(feature = "cargo-clippy", allow(clippy::module_name_repetitions))]
 pub struct IdMapping {
     /// The old crate.
     old_crate: CrateNum,
@@ -297,7 +297,7 @@ impl IdMapping {
 ///
 /// Both old and new exports can be missing. Allows for reuse of the `HashMap`s used for storage.
 #[derive(Default)]
-#[cfg_attr(feature = "cargo-clippy", allow(clippy::stutter))]
+#[cfg_attr(feature = "cargo-clippy", allow(clippy::module_name_repetitions))]
 pub struct NameMapping {
     /// The exports in the type namespace.
     type_map: HashMap<Name, (Option<Export>, Option<Export>)>,

--- a/src/semcheck/mismatch.rs
+++ b/src/semcheck/mismatch.rs
@@ -22,7 +22,7 @@ use std::collections::{HashMap, HashSet, VecDeque};
 /// Keeps track of item pairs found that way that correspond to item matchings not yet known.
 /// This allows to match up some items that aren't exported, and which possibly even differ in
 /// their names across versions.
-#[cfg_attr(feature = "cargo-clippy", allow(clippy::stutter))]
+#[cfg_attr(feature = "cargo-clippy", allow(clippy::module_name_repetitions))]
 pub struct MismatchRelation<'a, 'gcx: 'a + 'tcx, 'tcx: 'a> {
     /// The type context used.
     tcx: TyCtxt<'a, 'gcx, 'tcx>,

--- a/src/semcheck/translate.rs
+++ b/src/semcheck/translate.rs
@@ -479,7 +479,7 @@ impl<'a, 'gcx, 'tcx> TranslationContext<'a, 'gcx, 'tcx> {
         self.translate_predicates(orig_def_id, param_env.caller_bounds)
             .map(|target_preds| ParamEnv {
                 caller_bounds: self.tcx.intern_predicates(&target_preds),
-                reveal: param_env.reveal,
+                ..param_env
             })
     }
 

--- a/src/semcheck/traverse.rs
+++ b/src/semcheck/traverse.rs
@@ -386,11 +386,11 @@ fn diff_adts(changes: &mut ChangeSet, id_mapping: &mut IdMapping, tcx: TyCtxt, o
     let mut fields = BTreeMap::new();
 
     for variant in &old_def.variants {
-        variants.entry(variant.name).or_insert((None, None)).0 = Some(variant);
+        variants.entry(variant.ident.name).or_insert((None, None)).0 = Some(variant);
     }
 
     for variant in &new_def.variants {
-        variants.entry(variant.name).or_insert((None, None)).1 = Some(variant);
+        variants.entry(variant.ident.name).or_insert((None, None)).1 = Some(variant);
     }
 
     for items in variants.values() {


### PR DESCRIPTION
Instead of having a custom `CompilerCalls` impl, the analysis pass
is just injected into the default compiler. 

r? @oli-obk  - I hope I updated this properly like we talked about on discord, but I would prefer if you would take a look at this. All the tests pass on my machine, but this still does not fix #81 (I'll send a PR for that afterwards).