### PR TITLE
Fix exit code of rust-semverver in tests

### DIFF
--- a/ci/run.sh
+++ b/ci/run.sh
@@ -2,6 +2,9 @@
 
 set -ex
 
+# Note: this is required for correctness,
+# otherwise executing multiple "full" tests in parallel
+# of the same library can alter results.
 export RUST_TEST_THREADS=1
 export RUST_BACKTRACE=full
 #export RUST_TEST_NOCAPTURE=1

--- a/src/bin/cargo_semver.rs
+++ b/src/bin/cargo_semver.rs
@@ -179,7 +179,9 @@ fn run(config: &cargo::Config, matches: &getopts::Matches, explain: bool) -> Res
              extern crate new;"
         ))?;
     } else {
-        return Err(failure::err_msg("could not pipe to rustc (wtf?)".to_owned()).into());
+        return Err(failure::err_msg(
+            "could not pipe to rustc (wtf?)".to_owned(),
+        ));
     }
 
     let exit_status = child
@@ -438,7 +440,6 @@ pub fn find_on_crates_io(crate_name: &str) -> Result<crates_io::Crate> {
                 "failed to retrieve search results from the registry: {}",
                 e
             ))
-            .into()
         })
         .and_then(|(mut crates, _)| {
             crates
@@ -446,7 +447,6 @@ pub fn find_on_crates_io(crate_name: &str) -> Result<crates_io::Crate> {
                 .find(|krate| krate.name == crate_name)
                 .ok_or_else(|| {
                     failure::err_msg(format!("failed to find a matching crate `{}`", crate_name))
-                        .into()
                 })
         })
 }

--- a/src/bin/cargo_semver.rs
+++ b/src/bin/cargo_semver.rs
@@ -419,6 +419,14 @@ impl<'a> WorkInfo<'a> {
         // TODO: handle multiple outputs gracefully
         for i in &build_plan.invocations {
             if i.package_name == name {
+                // FIXME: this is a hack to avoid picking up output artifacts of
+                // build scrits and build programs (no outputs):
+                let build_script =
+                    i.outputs.iter().any(|v| v.to_str().unwrap().contains("build_script"));
+                let build_program = i.outputs.is_empty();
+                if build_script || build_program {
+                    continue;
+                }
                 return Ok((i.outputs[0].clone(), compilation.deps_output));
             }
         }

--- a/src/bin/cargo_semver.rs
+++ b/src/bin/cargo_semver.rs
@@ -153,6 +153,10 @@ fn run(config: &cargo::Config, matches: &getopts::Matches, explain: bool) -> Res
         child.args(&["--target", &target]);
     }
 
+    if !matches.opt_present("no-default-features") {
+        child.args(&["--cfg", "feature=\"default\""]);
+    }
+
     let child = child
         .arg("-")
         .stdin(Stdio::piped())
@@ -214,6 +218,11 @@ mod cli {
             "a",
             "api-guidelines",
             "report only changes that are breaking according to the API-guidelines",
+        );
+        opts.optflag(
+            "",
+            "no-default-features",
+            "Do not activate the `default` feature",
         );
         opts.optopt(
             "s",
@@ -397,6 +406,7 @@ impl<'a> WorkInfo<'a> {
         if let Some(target) = matches.opt_str("target") {
             opts.build_config.requested_target = Some(target);
         }
+        opts.no_default_features = matches.opt_present("no-default-features");
 
         // TODO: this is where we could insert feature flag builds (or using the CLI mechanisms)
 

--- a/src/bin/cargo_semver.rs
+++ b/src/bin/cargo_semver.rs
@@ -182,11 +182,15 @@ fn run(config: &cargo::Config, matches: &getopts::Matches, explain: bool) -> Res
         return Err(failure::err_msg("could not pipe to rustc (wtf?)".to_owned()).into());
     }
 
-    child
+    let exit_status = child
         .wait()
         .map_err(|e| failure::err_msg(format!("failed to wait for rustc: {}", e)))?;
 
-    Ok(())
+    if exit_status.success() {
+        Ok(())
+    } else {
+        Err(failure::err_msg("rustc-semverver errored".to_owned()))
+    }
 }
 
 /// CLI utils

--- a/src/bin/cargo_semver.rs
+++ b/src/bin/cargo_semver.rs
@@ -11,9 +11,9 @@ use cargo::core::{Package, PackageId, PackageSet, Source, SourceId, SourceMap, W
 use log::debug;
 use std::{
     env,
+    fs::File,
     io::BufReader,
     io::Write,
-    fs::File,
     path::{Path, PathBuf},
     process::{Command, Stdio},
 };
@@ -390,8 +390,10 @@ impl<'a> WorkInfo<'a> {
         opts.build_config.build_plan = true;
         // TODO: this is where we could insert feature flag builds (or using the CLI mechanisms)
 
-        env::set_var("RUSTFLAGS",
-                     format!("-C metadata={}", if current { "new" } else { "old" }));
+        env::set_var(
+            "RUSTFLAGS",
+            format!("-C metadata={}", if current { "new" } else { "old" }),
+        );
 
         let mut outdir = env::temp_dir();
         outdir.push(&format!("cargo_semver_{}_{}", name, current));
@@ -410,8 +412,7 @@ impl<'a> WorkInfo<'a> {
         let compilation = cargo::ops::compile(&self.workspace, &opts)?;
         env::remove_var("RUSTFLAGS");
 
-        let build_plan: BuildPlan =
-            serde_json::from_reader(BufReader::new(File::open(&outdir)?))?;
+        let build_plan: BuildPlan = serde_json::from_reader(BufReader::new(File::open(&outdir)?))?;
 
         // TODO: handle multiple outputs gracefully
         for i in &build_plan.invocations {

--- a/src/bin/rust_semverver.rs
+++ b/src/bin/rust_semverver.rs
@@ -1,5 +1,4 @@
 #![feature(rustc_private)]
-#![feature(try_from)]
 
 extern crate getopts;
 extern crate rustc;

--- a/src/changes.rs
+++ b/src/changes.rs
@@ -875,7 +875,7 @@ impl<'tcx> ChangeSet<'tcx> {
     pub fn trait_item_breaking(&self, old: DefId) -> bool {
         self.changes
             .get(&old)
-            .map_or(false, |change| change.trait_item_breaking())
+            .map_or(false, Change::trait_item_breaking)
     }
 
     /// Format the contents of a change set for user output.

--- a/tests/cases/regions/stdout
+++ b/tests/cases/regions/stdout
@@ -31,5 +31,21 @@ error: breaking changes in `def`
    |
    = warning: type error: expected reference, found bool (breaking)
 
-error: aborting due to 4 previous errors
+error: breaking changes in `efg`
+  --> $REPO_PATH/tests/cases/regions/new.rs:17:1
+   |
+17 | pub fn efg(_: &str) { }
+   | ^^^^^^^^^^^^^^^^^^^^^^^
+   |
+   = warning: type error: expected bound lifetime parameterBrAnon(0), found concrete lifetime (breaking)
+
+error: breaking changes in `fgh`
+  --> $REPO_PATH/tests/cases/regions/new.rs:19:1
+   |
+19 | pub fn fgh(_: &'static str) { }
+   | ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
+   |
+   = warning: type error: expected bound lifetime parameterBrAnon(0), found concrete lifetime (breaking)
+
+error: aborting due to 6 previous errors
 

--- a/tests/examples.rs
+++ b/tests/examples.rs
@@ -81,7 +81,7 @@ mod features {
             let rustsemverver_result = cmd.status().expect("could not run rust-semverver").success();
             assert_eq!(
                 rustsemverver_result, expected_result,
-                "rust-semverver returned an unexpected result"
+                "rust-semverver returned an unexpected exit status"
             );
 
             {
@@ -130,7 +130,7 @@ mod features {
             .expect("could not run git diff")
             .success();
 
-        assert!(git_result, "git reports a diff");
+        assert!(git_result, "git reports unexpected diff");
 
         Command::new("rm")
             .args(&[&old_rlib, &new_rlib])

--- a/tests/examples.rs
+++ b/tests/examples.rs
@@ -78,7 +78,10 @@ mod features {
                 cmd.env("RUST_SEMVER_API_GUIDELINES", "true");
             }
 
-            let rustsemverver_result = cmd.status().expect("could not run rust-semverver").success();
+            let rustsemverver_result = cmd
+                .status()
+                .expect("could not run rust-semverver")
+                .success();
             assert_eq!(
                 rustsemverver_result, expected_result,
                 "rust-semverver returned an unexpected exit status"

--- a/tests/examples.rs
+++ b/tests/examples.rs
@@ -5,9 +5,7 @@ mod features {
         process::{Command, Stdio},
     };
 
-    fn test_example(path: &Path, out_file: &Path) {
-        let mut success = true;
-
+    fn test_example(path: &Path, out_file: &Path, expected_result: bool) {
         let old_rlib = path.join("libold.rlib").to_str().unwrap().to_owned();
         let new_rlib = path.join("libnew.rlib").to_str().unwrap().to_owned();
 
@@ -29,8 +27,8 @@ mod features {
                 cmd.args(target_args);
             }
 
-            success &= cmd.status().expect("could not run rustc").success();
-            assert!(success, "couldn't compile old");
+            let rustc_old_result = cmd.status().expect("could not run rustc on old").success();
+            assert!(rustc_old_result, "couldn't compile old");
 
             let mut cmd = Command::new("rustc");
             cmd.args(&["--crate-type=lib", "-o", &new_rlib])
@@ -42,9 +40,8 @@ mod features {
                 cmd.args(target_args);
             }
 
-            success &= cmd.status().expect("could not run rustc").success();
-
-            assert!(success, "couldn't compile new");
+            let rustc_new_result = cmd.status().expect("could not run rustc on new").success();
+            assert!(rustc_new_result, "couldn't compile new");
 
             let mut cmd = Command::new(
                 Path::new(".")
@@ -81,12 +78,11 @@ mod features {
                 cmd.env("RUST_SEMVER_API_GUIDELINES", "true");
             }
 
-            success &= cmd
-                .status()
-                .expect("could not run rust-semverver")
-                .success();
-
-            assert!(success, "rust-semverver");
+            let rustsemverver_result = cmd.status().expect("could not run rust-semverver").success();
+            assert_eq!(
+                rustsemverver_result, expected_result,
+                "rust-semverver returned an unexpected result"
+            );
 
             {
                 // replace root path with with $REPO_PATH
@@ -122,7 +118,7 @@ mod features {
             }
         }
 
-        success &= Command::new("git")
+        let git_result = Command::new("git")
             .args(&[
                 "diff",
                 "--ignore-space-at-eol",
@@ -134,7 +130,7 @@ mod features {
             .expect("could not run git diff")
             .success();
 
-        assert!(success, "git");
+        assert!(git_result, "git reports a diff");
 
         Command::new("rm")
             .args(&[&old_rlib, &new_rlib])
@@ -143,54 +139,57 @@ mod features {
     }
 
     macro_rules! test {
-        ($name:ident) => {
+        ($name:ident => $result:literal) => {
             #[test]
             fn $name() {
                 let path = Path::new("tests").join("cases").join(stringify!($name));
-                test_example(&path, &path.join("stdout"));
+                test_example(&path, &path.join("stdout"), $result);
 
                 if path.join("stdout_api_guidelines").exists() {
                     eprintln!("api-guidelines");
-                    test_example(&path, &path.join("stdout_api_guidelines"));
+                    test_example(&path, &path.join("stdout_api_guidelines"), $result);
                 }
             }
         };
-        ($($name:ident),*) => {
-            $(test!($name);)*
-        }
+        ($($name:ident => $result:literal),*) => {
+            $(test!($name => $result);)*
+        };
+        ($($name:ident => $result:literal,)*) => {
+            $(test!($name => $result);)*
+        };
     }
 
     test! {
-        addition,
-        addition_path,
-        addition_use,
-        bounds,
-        circular,
-        consts,
-        enums,
-        func,
-        func_local_items,
-        infer,
-        infer_regress,
-        inherent_impls,
-        issue_34,
-        issue_50,
-        kind_change,
-        macros,
-        max_priv,
-        mix,
-        pathologic_paths,
-        pub_use,
-        regions,
-        removal,
-        removal_path,
-        removal_use,
-        sealed_traits,
-        structs,
-        swap,
-        traits,
-        trait_impls,
-        trait_objects,
-        ty_alias
+        addition => true,
+        addition_path => true,
+        addition_use => false,
+        bounds => false,
+        circular => true,
+        consts => false,
+        enums => false,
+        func => false,
+        func_local_items => true,
+        infer => true,
+        infer_regress => false,
+        inherent_impls => false,
+        issue_34 => true,
+        issue_50 => true,
+        kind_change => false,
+        macros => false,
+        max_priv => true,
+        mix => false,
+        pathologic_paths => true,
+        pub_use => true,
+        regions => false,
+        removal => false,
+        removal_path => false,
+        removal_use => false,
+        sealed_traits => true,
+        structs => false,
+        swap => true,
+        traits => false,
+        trait_impls => false,
+        trait_objects => true,
+        ty_alias => false,
     }
 }

--- a/tests/full.rs
+++ b/tests/full.rs
@@ -6,9 +6,12 @@ mod full {
         process::{Command, Stdio},
     };
 
-    fn test_full(crate_name: &str, old_version: &str, new_version: &str) {
-        let mut success = true;
-
+    fn test_full(
+        crate_name: &str,
+        old_version: &str,
+        new_version: &str,
+        expected_result: bool
+    ) {
         let prog = format!(
             r#"
     # wait for the actual output
@@ -90,7 +93,7 @@ mod full {
         let old_version = format!("{}:{}", crate_name, old_version);
         let new_version = format!("{}:{}", crate_name, new_version);
 
-        success &= {
+        let cargo_semver_result = {
             let mut cmd = Command::new("./target/debug/cargo-semver");
             cmd.args(&["-S", &old_version, "-C", &new_version])
                 .env("RUST_BACKTRACE", "full")
@@ -105,36 +108,41 @@ mod full {
             cmd.status().expect("could not run cargo semver").success()
         };
 
-        assert!(success, "cargo semver");
+        assert_eq!(
+            cargo_semver_result, expected_result,
+            "cargo semver returned an unexpected exit status"
+        );
 
-        success &= awk_child
+        let awk_result = awk_child
             .wait()
             .expect("could not wait for awk child")
             .success();
 
-        assert!(success, "awk");
+        assert!(awk_result, "awk");
 
-        success &= Command::new("git")
+        let git_result = Command::new("git")
             .args(&["diff", "--ignore-space-at-eol", "--exit-code", out_file])
             .env("PAGER", "")
             .status()
             .expect("could not run git diff")
             .success();
 
-        assert!(success, "git");
+        assert!(git_result, "git reports unexpected diff");
     }
 
     macro_rules! full_test {
-        ($name:ident, $crate_name:expr, $old_version:expr, $new_version:expr) => {
+        ($name:ident, $crate_name:expr,
+         $old_version:expr, $new_version:expr,
+         $result:literal) => {
             #[test]
             fn $name() {
-                test_full($crate_name, $old_version, $new_version);
+                test_full($crate_name, $old_version, $new_version, $result);
             }
         };
     }
 
-    full_test!(log, "log", "0.3.4", "0.3.8");
-    full_test!(libc, "libc", "0.2.28", "0.2.31");
+    full_test!(log, "log", "0.3.4", "0.3.8", true);
+    full_test!(libc, "libc", "0.2.28", "0.2.31", false);
     // full_test!(mozjs, "mozjs", "0.2.0", "0.3.0");
     // full_test!(rand, "rand", "0.3.10", "0.3.16");
     // full_test!(serde_pre, "serde", "0.7.0", "1.0.0");

--- a/tests/full.rs
+++ b/tests/full.rs
@@ -46,7 +46,11 @@ mod full {
         };
 
         let out_file: PathBuf = format!("{}.{}", out_file.display(), file_ext).into();
-        assert!(out_file.exists(), "file `{}` does not exist", out_file.display());
+        assert!(
+            out_file.exists(),
+            "file `{}` does not exist",
+            out_file.display()
+        );
 
         if let Some(path) = env::var_os("PATH") {
             let mut paths = env::split_paths(&path).collect::<Vec<_>>();
@@ -94,8 +98,7 @@ mod full {
                 .env("RUST_BACKTRACE", "full")
                 .stdin(Stdio::null())
                 .stdout(out_pipe)
-                .stderr(err_pipe)
-                ;
+                .stderr(err_pipe);
 
             if let Ok(target) = std::env::var("TEST_TARGET") {
                 cmd.args(&["--target", &target]);

--- a/tests/full.rs
+++ b/tests/full.rs
@@ -6,12 +6,7 @@ mod full {
         process::{Command, Stdio},
     };
 
-    fn test_full(
-        crate_name: &str,
-        old_version: &str,
-        new_version: &str,
-        expected_result: bool
-    ) {
+    fn test_full(crate_name: &str, old_version: &str, new_version: &str, expected_result: bool) {
         let prog = format!(
             r#"
     # wait for the actual output

--- a/tests/full.rs
+++ b/tests/full.rs
@@ -46,7 +46,7 @@ mod full {
         };
 
         let out_file: PathBuf = format!("{}.{}", out_file.display(), file_ext).into();
-        assert!(out_file.exists());
+        assert!(out_file.exists(), "file `{}` does not exist", out_file.display());
 
         if let Some(path) = env::var_os("PATH") {
             let mut paths = env::split_paths(&path).collect::<Vec<_>>();
@@ -94,7 +94,8 @@ mod full {
                 .env("RUST_BACKTRACE", "full")
                 .stdin(Stdio::null())
                 .stdout(out_pipe)
-                .stderr(err_pipe);
+                .stderr(err_pipe)
+                ;
 
             if let Ok(target) = std::env::var("TEST_TARGET") {
                 cmd.args(&["--target", &target]);
@@ -137,7 +138,8 @@ mod full {
     }
 
     full_test!(log, "log", "0.3.4", "0.3.8", true);
-    full_test!(libc, "libc", "0.2.28", "0.2.31", false);
+    full_test!(libc0, "libc", "0.2.28", "0.2.31", false);
+    full_test!(libc1, "libc", "0.2.47", "0.2.48", true);
     // full_test!(mozjs, "mozjs", "0.2.0", "0.3.0");
     // full_test!(rand, "rand", "0.3.10", "0.3.16");
     // full_test!(serde_pre, "serde", "0.7.0", "1.0.0");

--- a/tests/full_cases/libc-0.2.28-0.2.31.linux
+++ b/tests/full_cases/libc-0.2.28-0.2.31.linux
@@ -867,3 +867,5 @@ note: added path (technically breaking)
 
 error: aborting due to 11 previous errors
 
+error: rustc-semverver errored
+

--- a/tests/full_cases/libc-0.2.28-0.2.31.osx
+++ b/tests/full_cases/libc-0.2.28-0.2.31.osx
@@ -2370,4 +2370,3 @@ note: added path (technically breaking)
 error: aborting due to previous error
 
 error: rustc-semverver errored
-

--- a/tests/full_cases/libc-0.2.28-0.2.31.osx
+++ b/tests/full_cases/libc-0.2.28-0.2.31.osx
@@ -2369,3 +2369,5 @@ note: added path (technically breaking)
 
 error: aborting due to previous error
 
+error: rustc-semverver errored
+

--- a/tests/full_cases/libc-0.2.47-0.2.48.osx
+++ b/tests/full_cases/libc-0.2.47-0.2.48.osx
@@ -1,0 +1,1 @@
+version bump: 0.2.47 -> (patch) -> 0.2.48


### PR DESCRIPTION
So it turned out that the bug with rust-semverver returning an incorrect exit code on error (it always returned success) wasn't in rust-semverver, but in rustc itself. This is now fixed upstream (https://github.com/rust-lang/rust/pull/58400), which makes all tests that should return an error exit code fail. This PR fixes that. 