### PR TITLE
Less awkward tests

### DIFF
--- a/src/bin/cargo_semver.rs
+++ b/src/bin/cargo_semver.rs
@@ -62,6 +62,10 @@ fn main() {
         return;
     }
 
+    if matches.opt_present("q") {
+        config.shell().set_verbosity(cargo::core::shell::Verbosity::Quiet);
+    }
+
     if let Err(e) = cli::validate_args(&matches) {
         cli::exit_with_error(&config, e);
     }
@@ -214,6 +218,7 @@ mod cli {
         opts.optflag("h", "help", "print this message and exit");
         opts.optflag("V", "version", "print version information and exit");
         opts.optflag("e", "explain", "print detailed error explanations");
+        opts.optflag("q", "quiet", "surpress regular cargo output, print only important messages");
         opts.optflag("d", "debug", "print command to debug and exit");
         opts.optflag(
             "a",
@@ -293,6 +298,7 @@ mod cli {
 
     /// Exit with error `e`.
     pub fn exit_with_error(config: &cargo::Config, e: failure::Error) -> ! {
+        config.shell().set_verbosity(cargo::core::shell::Verbosity::Normal);
         cargo::exit_with_error(CliError::new(e, 1), &mut config.shell());
     }
 }


### PR DESCRIPTION
The current setup in `tests/full.rs` uses awk to filter cargo-semver's output and has a bunch of platform-specific code in order to handle this.

This PR changes the tests to instead filter the output using pure rust.
It also introduces a `-q` flag to cargo-semver that tells it to only output its own messages and not ones from cargo itself. This makes the filtering considerably simpler.