### PR TITLE
Make `tests/full.rs` no longer use `git diff`

### DIFF
--- a/build.rs
+++ b/build.rs
@@ -1,0 +1,6 @@
+// This does nothing.
+// It is only there because cargo will only set the $OUT_DIR env variable
+// for tests if there is a build script.
+fn main() {
+    println!("cargo:rerun-if-changed=build.rs");
+}


### PR DESCRIPTION
Currently, `tests/full.rs` will overwrite the files containing the expected output of cargo-semver with its actual output, then call `git diff` to see if there are any changes. This has a couple of downsides as discussed in #99.

This PR changes the behavior to do the following instead:
1. Capture the new output in memory and compare it against the stored version.
2. If they differ, put the new version into $OUT_DIR for inspection.
3. To make up for the lost functionality from `git diff`, suggest a command to view the diff.

This means that tests can now run even if the source directory is read-only, not checked out via git, or if git is not installed at all. It also means that failing tests do not cause a dirty working tree any more and `cargo clean` as well as `git clean -x` work as intended.