### PR TITLE
Rustup to the latest nightly

### DIFF
--- a/ci/run.sh
+++ b/ci/run.sh
@@ -7,9 +7,9 @@ export RUST_BACKTRACE=full
 
 cargo +nightly install rustup-toolchain-install-master
 if [ "${TRAVIS_OS_NAME}" = "windows" ]; then
-    rustup-toolchain-install-master -f -n master -c rustc-dev -i x86_64-pc-windows-msvc
+    rustup-toolchain-install-master -f -n master -c rustc-dev -c llvm-tools -i x86_64-pc-windows-msvc
 else
-    rustup-toolchain-install-master -f -n master -c rustc-dev
+    rustup-toolchain-install-master -f -n master -c rustc-dev -c llvm-tools
 fi
 rustup override set master
 

--- a/src/traverse.rs
+++ b/src/traverse.rs
@@ -570,7 +570,7 @@ fn diff_traits<'tcx>(
 ) {
     use rustc_hir::Unsafety::Unsafe;
     use rustc_middle::ty::subst::GenericArgKind::Type;
-    use rustc_middle::ty::{ParamTy, Predicate, TyS};
+    use rustc_middle::ty::{ParamTy, PredicateKind, TyS};
 
     debug!(
         "diff_traits: old: {:?}, new: {:?}, output: {:?}",
@@ -592,7 +592,7 @@ fn diff_traits<'tcx>(
     let old_param_env = tcx.param_env(old);
 
     for bound in old_param_env.caller_bounds {
-        if let Predicate::Trait(pred, _) = *bound {
+        if let PredicateKind::Trait(pred, _) = *bound.kind() {
             let trait_ref = pred.skip_binder().trait_ref;
 
             debug!("trait_ref substs (old): {:?}", trait_ref.substs);

--- a/tests/full_cases/log-0.3.4-0.3.8.osx
+++ b/tests/full_cases/log-0.3.4-0.3.8.osx
@@ -23,7 +23,7 @@ warning: technically breaking changes in `<new::LogRecord<'a> as std::fmt::Debug
     |
     = note: trait impl generalized or newly added (technically breaking)
 
-warning: technically breaking changes in `<new::LogMetadata<'a> as std::cmp::Eq>`
+warning: technically breaking changes in `<new::LogMetadata<'a> as std::marker::StructuralEq>`
    --> log-0.3.8/src/lib.rs:552:10
     |
 552 | #[derive(Eq, PartialEq, Ord, PartialOrd, Hash, Debug)]
@@ -71,7 +71,7 @@ warning: technically breaking changes in `<new::LogMetadata<'a> as std::fmt::Deb
     |
     = note: trait impl generalized or newly added (technically breaking)
 
-warning: technically breaking changes in `<new::LogLocation as std::cmp::Eq>`
+warning: technically breaking changes in `<new::LogLocation as std::marker::StructuralEq>`
    --> log-0.3.8/src/lib.rs:604:30
     |
 604 | #[derive(Copy, Clone, Debug, Eq, PartialEq, Ord, PartialOrd, Hash)]


### PR DESCRIPTION
Rustup to https://github.com/rust-lang/rust/pull/72055. Also adds `llvm-tools` component as we now use LLVM 10 as backend.

r? @Manishearth 